### PR TITLE
fix(img): update Dockerfile to use custom configuration file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,8 @@ USER root
 WORKDIR /app
 
 # Copy base + dsfr config
-COPY --from=dsfr_image /app/superset-dsfr/docker/pythonpath_dev/superset_config_docker.py /app/pythonpath/superset_config.py
+ENV SUPERSET_CONFIG_PATH=/app/pythonpath/superset_config_base_dsfr.py
+COPY --from=dsfr_image /app/superset-dsfr/docker/pythonpath_dev/superset_config_docker.py /app/pythonpath/superset_config_base_dsfr.py
 
 # Copy DSFR assets from dsfr_image stage
 COPY --from=dsfr_image /app/dsfr-base/dist /app/superset/static/assets/dsfr

--- a/superset/docker/pythonpath_dev/superset_config_docker.py
+++ b/superset/docker/pythonpath_dev/superset_config_docker.py
@@ -12,7 +12,7 @@ LOGO_TOOLTIP = "ChartsGouv"
 APP_NAME = "ChartsGouv"
 
 # Specify the App icon
-APP_ICON = "/static/assets/local/images/app_icon.png"
+APP_ICON = "/static/assets/local/images/app_icon_avec_titre_horizontal.png"
 
 DSFR_COLORS = {
   "sun": {


### PR DESCRIPTION
Utilisation d'un nom spécifique pour le fichier de configuration dsfr et utilisation de la vraible d
'environnement SUPERSET_CONFIG_PATH pour charger ce fichier de configuration.
L'objectif est de rendre l'image exploitable par défaut dans un environnement helm